### PR TITLE
Test enhancement

### DIFF
--- a/tests/StreamFactoryTest.php
+++ b/tests/StreamFactoryTest.php
@@ -61,6 +61,7 @@ class StreamFactoryTest extends TestCase
 	public function testCreateStreamFromUnopenableFile()
 	{
 		$this->expectException(UnopenableStreamException::class);
+		$this->expectExceptionMessage(\sprintf('Unable to open file "%s/nonexistent.file" in mode "r"', __DIR__));
 
 		(new StreamFactory)->createStreamFromFile(__DIR__ . '/nonexistent.file', 'r');
 	}

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -15,12 +15,12 @@ class StreamTest extends TestCase
 {
 	private $handle;
 
-	public function setUp()
+	protected function setUp()
 	{
 		$this->handle = \fopen('php://memory', 'r+b');
 	}
 
-	public function tearDown()
+	protected function tearDown()
 	{
 		if (\is_resource($this->handle))
 		{
@@ -50,7 +50,7 @@ class StreamTest extends TestCase
 
 		$this->assertEquals($this->handle, $stream->detach());
 		$this->assertStreamResourceEquals($stream, null);
-		$this->assertEquals(null, $stream->detach());
+		$this->assertNull($stream->detach());
 	}
 
 	public function testClose()
@@ -305,7 +305,7 @@ class StreamTest extends TestCase
 		$stream = new Stream($this->handle);
 
 		$stream->close();
-		$this->assertEquals(null, $stream->getMetadata());
+		$this->assertNull($stream->getMetadata());
 	}
 
 	public function testGetSize()
@@ -327,7 +327,7 @@ class StreamTest extends TestCase
 		$stream = new Stream($this->handle);
 
 		$stream->close();
-		$this->assertEquals(null, $stream->getSize());
+		$this->assertNull($stream->getSize());
 	}
 
 	public function testToString()


### PR DESCRIPTION
# Changed log
- Add the `expectExceptionMessage` to check whether the expected message is same as result.
- According to the [Fixtures](https://phpunit.readthedocs.io/en/latest/search.html?q=fixtures&check_keywords=yes&area=default) reference, the `PHPUnit\Framework\TestCase::setUp` should be `protected`, not `public`.
- Using the `assertNull` to check whether the expected value is `null`.